### PR TITLE
feat: add support for posting multiple orders

### DIFF
--- a/examples/authenticated_trading.rs
+++ b/examples/authenticated_trading.rs
@@ -2,7 +2,7 @@ use alloy_signer_local::PrivateKeySigner;
 use polymarket_rs::client::{AuthenticatedClient, TradingClient};
 use polymarket_rs::orders::OrderBuilder;
 use polymarket_rs::types::{CreateOrderOptions, OrderArgs, Side, SignatureType};
-use polymarket_rs::Result;
+use polymarket_rs::{OrderType, Result};
 use rust_decimal::Decimal;
 use std::str::FromStr;
 
@@ -66,45 +66,42 @@ async fn main() -> Result<()> {
         Side::Buy,
     );
 
-    let _options = CreateOrderOptions::default()
+    let options = CreateOrderOptions::default()
         .tick_size(Decimal::from_str("0.01").unwrap())
         .neg_risk(false);
 
-    // Note: This creates the order but doesn't post it
-    // Uncomment the following to actually post:
-    // let signed_order = trading_client.create_order(
-    //     &_order_args,
-    //     None,      // expiration (defaults to 0 = no expiration)
-    //     None,      // extras (defaults to ExtraOrderArgs::default())
-    //     _options,
-    // )?;
-    //
-    // println!("Created signed order with salt: {}", signed_order.salt);
-    //
-    // // Post the order
-    // let result = trading_client.post_order(signed_order, OrderType::Gtc).await?;
-    // println!("Order posted: {:?}", result);
+    let signed_order = trading_client.create_order(
+        &_order_args,
+        None, // expiration (defaults to 0 = no expiration)
+        None, // extras (defaults to ExtraOrderArgs::default())
+        options,
+    )?;
 
-    println!("Order creation example completed (not posted)");
+    println!("Created signed order with salt: {}", signed_order.salt);
+
+    // Post the order
+    let result = trading_client
+        .post_order(signed_order, OrderType::Gtc)
+        .await?;
+    println!("Order posted: {:?}", result);
 
     // Step 5: Cancel market orders (example - NOT executed)
     println!("\n5. Cancel market orders example...");
-    // Uncomment to cancel orders for a specific market:
-    // let result = trading_client.cancel_market_orders(Some("0xaaa"), None).await?;
+
+    // Cancel orders for a specific market:
+    let result = trading_client
+        .cancel_market_orders(Some("0xaaa"), None)
+        .await?;
     // Or cancel by asset_id:
     // let result = trading_client.cancel_market_orders(None, Some("100")).await?;
     // Or both:
     // let result = trading_client.cancel_market_orders(Some("0xaaa"), Some("100")).await?;
-    println!("Cancel market orders example completed (not executed)");
+    println!("Cancelled orders: {:?}", result);
 
     // Step 6: Get trade history
     println!("\n6. Fetching trade history...");
     let trades = trading_client.get_trades(Default::default()).await?;
     println!("Trade history: {:?}", trades);
-
-    println!("\n✓ Example completed successfully!");
-    println!("\nNOTE: This example did not post any actual orders.");
-    println!("Uncomment the posting code to execute real trades.");
 
     // ========================================================================
     // POLYPROXY WALLET EXAMPLE

--- a/examples/post_multiple_orders.rs
+++ b/examples/post_multiple_orders.rs
@@ -1,0 +1,111 @@
+use alloy_signer_local::PrivateKeySigner;
+use polymarket_rs::client::{AuthenticatedClient, TradingClient};
+use polymarket_rs::orders::OrderBuilder;
+use polymarket_rs::types::{
+    CreateOrderOptions, OrderArgs, OrderType, PostOrderArgs, Side, SignatureType,
+};
+use polymarket_rs::Result;
+use rust_decimal::Decimal;
+use std::str::FromStr;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Replace with your actual private key
+    let private_key =
+        std::env::var("PRIVATE_KEY").expect("PRIVATE_KEY environment variable not set");
+
+    let signer = PrivateKeySigner::from_str(&private_key).expect("Invalid private key");
+
+    let chain_id = 137; // Polygon Mainnet
+    let host = "https://clob.polymarket.com";
+
+    println!("Signer address: {}", signer.address());
+
+    // Step 1: Create or derive API credentials
+    println!("\n1. Creating/deriving API credentials...");
+    let auth_client = AuthenticatedClient::new(host, signer.clone(), chain_id, None, None);
+    let api_creds = auth_client.create_or_derive_api_key().await?;
+    println!("API Key: {}", api_creds.api_key);
+    println!("Successfully authenticated!");
+
+    // Step 2: Create a trading client
+    println!("\n2. Setting up trading client...");
+    let order_builder = OrderBuilder::new(signer.clone(), Some(SignatureType::Eoa), None);
+
+    let trading_client = TradingClient::new(
+        host,
+        signer.clone(),
+        chain_id,
+        api_creds.clone(),
+        order_builder,
+    );
+
+    // Step 3: Create multiple orders
+    println!("\n3. Creating multiple orders...");
+
+    // Specific token IDs
+    let token_id_1 = "";
+    let token_id_2 = "";
+
+    // Create order options (adjust tick_size and neg_risk as needed)
+    let options = CreateOrderOptions::default()
+        .tick_size(Decimal::from_str("0.01").unwrap())
+        .neg_risk(false);
+
+    // Create first order: BUY 10 tokens at 0.50
+    let order_args_1 = OrderArgs::new(
+        token_id_1,
+        Decimal::from_str("0.50").unwrap(), // price
+        Decimal::from_str("10.0").unwrap(), // size
+        Side::Buy,
+    );
+
+    let signed_order_1 = trading_client.create_order(&order_args_1, None, None, options.clone())?;
+    println!("Created order 1: BUY 10 @ 0.50");
+
+    // Create second order: SELL 15 tokens at 0.75
+    let order_args_2 = OrderArgs::new(
+        token_id_2,
+        Decimal::from_str("0.75").unwrap(), // price
+        Decimal::from_str("15.0").unwrap(), // size
+        Side::Sell,
+    );
+
+    let signed_order_2 = trading_client.create_order(&order_args_2, None, None, options.clone())?;
+    println!("Created order 2: SELL 15 @ 0.75");
+
+    // Create third order: BUY 5 tokens at 0.60
+    let order_args_3 = OrderArgs::new(
+        token_id_1,
+        Decimal::from_str("0.60").unwrap(), // price
+        Decimal::from_str("5.0").unwrap(),  // size
+        Side::Buy,
+    );
+
+    let signed_order_3 = trading_client.create_order(&order_args_3, None, None, options)?;
+    println!("Created order 3: BUY 5 @ 0.60");
+
+    // Step 4: Post all orders at once
+    println!("\n4. Posting multiple orders...");
+
+    let results = trading_client
+        .post_orders(&[
+            PostOrderArgs::new(signed_order_1, OrderType::Gtc),
+            PostOrderArgs::new(signed_order_2, OrderType::Gtc),
+            PostOrderArgs::new(signed_order_3, OrderType::Gtc),
+        ])
+        .await?;
+
+    println!("\n✅ Successfully posted {} orders!", results.len());
+
+    for (i, result) in results.iter().enumerate() {
+        println!("\nOrder {}:", i + 1);
+        println!("  Order ID: {}", result.order_id.as_str());
+        println!("  Status: {}", result.status);
+        println!("  Success: {}", result.success);
+        if !result.error_msg.is_empty() {
+            println!("  Error: {}", result.error_msg);
+        }
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use alloy_signer_local::PrivateKeySigner;
 pub use error::{Error, Result};
 pub use types::{
     ApiCreds, AssetType, ConditionId, CreateOrderOptions, ExtraOrderArgs, MarketOrderArgs,
-    OrderArgs, OrderId, OrderType, Side, SignatureType, TokenId,
+    OrderArgs, OrderId, OrderType, PostOrderArgs, Side, SignatureType, TokenId,
 };
 
 // Re-export clients

--- a/src/types/order.rs
+++ b/src/types/order.rs
@@ -287,6 +287,19 @@ pub struct PostOrderResponse {
     pub success: bool,
 }
 
+/// Arguments for posting multiple orders
+#[derive(Debug, Clone)]
+pub struct PostOrderArgs {
+    pub order: SignedOrderRequest,
+    pub order_type: OrderType,
+}
+
+impl PostOrderArgs {
+    pub fn new(order: SignedOrderRequest, order_type: OrderType) -> Self {
+        Self { order, order_type }
+    }
+}
+
 /// Response from canceling orders
 ///
 /// This response is returned by:


### PR DESCRIPTION
Implements the `post_orders` method to post multiple orders in a single API call

## Changes

### New Types
- **`PostOrderArgs`**: Struct to hold order and order type for batch posting

### New Method
- **`TradingClient::post_orders()`**: Post multiple orders atomically
  - Uses L2 authentication (same as single order posting)